### PR TITLE
Remove commented code and position menu properly on 1 page

### DIFF
--- a/src/layers/StatsGarageLayer.cpp
+++ b/src/layers/StatsGarageLayer.cpp
@@ -5,6 +5,10 @@
 
 using namespace geode::prelude;
 
+// for some reason, if i cast to PageMenu, i can't actually get m_fields->m_elementCount; it's just 0.
+// so we're making it a constant i guess
+const int ELEMENTS_PER_PAGE = 15;
+
 bool StatsGarageLayer::init() {
 	if (!GJGarageLayer::init())
 		return false;
@@ -12,21 +16,6 @@ bool StatsGarageLayer::init() {
 	auto winSize = CCDirector::get()->getWinSize();
 
 	m_fields->m_statsMenu = CCMenu::create();
-
-	/*
-	m_fields->m_nodeContainer.push_back(getExistingContainer("stars"));
-	m_fields->m_nodeContainer.push_back(getExistingContainer("moons"));
-	m_fields->m_nodeContainer.push_back(getExistingContainer("coins"));
-	m_fields->m_nodeContainer.push_back(getExistingContainer("user-coins"));
-	m_fields->m_nodeContainer.push_back(getExistingContainer("orbs"));
-	m_fields->m_nodeContainer.push_back(getExistingContainer("diamonds"));
-	m_fields->m_nodeContainer.push_back(getExistingContainer("diamond-shards"));
-
-	for (size_t i = 0; i < m_fields->m_nodeContainer.size(); i++) {
-		//m_fields->m_nodeContainer[i]->setLayout(AxisLayout::create()->setAutoScale(false)->setAxisReverse(true));
-		m_fields->m_statsMenu->addChild(m_fields->m_nodeContainer[i]);
-	}
-	*/
 
 	m_fields->m_statsMenu->setID("stats-menu"_spr);
 	m_fields->m_statsMenu->setZOrder(2);
@@ -41,7 +30,7 @@ bool StatsGarageLayer::init() {
 	m_fields->m_statsMenu->addChild(StatsDisplayAPI::getNewItem("diamonds", CCSprite::createWithSpriteFrameName("GJ_diamondsIcon_001.png"), GameStatsManager::sharedState()->getStat("13"), 0.6f));
 	m_fields->m_statsMenu->addChild(StatsDisplayAPI::getNewItem("diamond-shards", CCSprite::createWithSpriteFrameName("currencyDiamondIcon_001.png"), GameStatsManager::sharedState()->getStat("29"), 0.54f));
 
-	m_fields->m_statsMenu->setPosition(ccp(winSize.width - 18, winSize.height - 30));
+	m_fields->m_statsMenu->setPosition(ccp(winSize.width - 18, winSize.height - 12));
 
 	auto tempSprite = CCSprite::createWithSpriteFrameName("GJ_sideArt_001.png");
 	if (tempSprite) {
@@ -55,35 +44,20 @@ bool StatsGarageLayer::init() {
 	m_fields->m_statsMenu->updateLayout();
 
 	if (PagesAPI::isLoaded()) {
-		PageMenu* pageMenu = static_cast<PageMenu*>(m_fields->m_statsMenu); 
-		pageMenu->setPaged(15, PageOrientation::VERTICAL, m_fields->m_statsMenu->getContentHeight(), 12.f);
+    schedule(schedule_selector(StatsGarageLayer::moveMenuForArrows));
+    PageMenu* pageMenu = static_cast<PageMenu*>(m_fields->m_statsMenu); 
+		pageMenu->setPaged(ELEMENTS_PER_PAGE, PageOrientation::VERTICAL, m_fields->m_statsMenu->getContentHeight(), 12.f);
 		pageMenu->setButtonScale(0.6f);
-		// pageMenu->setPosition(ccp(winSize.width - 18, winSize.height - 12));
-		// pageMenu->setAnchorPoint(ccp(0.5f, 1.f));
 	}
-
-	// m_fields->m_statsMenu->updateLayout();
 
 	return true;
 }
 
-/*
-CCNode* StatsGarageLayer::getExistingContainer(std::string itemName) {
-	auto ret = CCMenu::create(); 
-	auto icon = this->getChildByID(itemName + "-icon");
-	if (icon) {
-		icon->removeFromParentAndCleanup(false);
-		ret->addChild(icon);
-		icon->setPosition({0, 0});
-	}
-	auto label = this->getChildByID(itemName + "-label"); 
-	if (label) {	
-		label->removeFromParentAndCleanup(false);
-		ret->addChild(label);
-		label->setPosition({-12, 0.5});
-	}
-	ret->setID(""_spr + itemName + "-container");
-	ret->setContentSize({ 0, 0 });
-	return ret;
+
+void StatsGarageLayer::moveMenuForArrows(float) {
+  auto winSize = CCDirector::get()->getWinSize();
+  if (m_fields->m_statsMenu->getChildrenCount() > ELEMENTS_PER_PAGE)
+    m_fields->m_statsMenu->setPosition(ccp(winSize.width - 18, winSize.height - 30));
+  else
+    m_fields->m_statsMenu->setPosition(ccp(winSize.width - 18, winSize.height - 12));
 }
-*/

--- a/src/layers/StatsGarageLayer.h
+++ b/src/layers/StatsGarageLayer.h
@@ -15,6 +15,8 @@ public:
 	};
 	$override
 	bool init();
+	
+  void moveMenuForArrows(float);
 
 	cocos2d::CCNode* getExistingContainer(std::string itemName);
 


### PR DESCRIPTION
If there isn't more than one page, the gap between the top of the screen and the start of the stats does not look like vanilla:
<img width="1919" height="1079" alt="image" src="https://github.com/user-attachments/assets/6578a8b8-4ac1-4146-8bea-837a33e47480" />

Whereas vanilla looks like this:
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/f0a83365-b96d-4f58-918b-370aa492e92c" />

This moves the menu to make it mirror vanilla if the arrows are hidden.

Note that I could not think of a way to do this without scheduling an update, given that technically, that menu may have children added to it at any point, and Pages API accounts for that, as it schedules its own update.

Also, for some reason I couldn't properly access `PageMenu::Fields::m_elementsCount` (which is, I *think* the elements per page count) by casting to PageMenu, it would just be 0. So, I hardcoded it to what it already was before, 15.

I also removed the commented-out code, as it should never be enabled again in the first place, given it removes vanilla nodes from the garage.
